### PR TITLE
Create readme

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---format documentation
---color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,5 @@
 ---
 AllCops:
-  # Disabling all cops by default in order to make an _explicit_ guide of what
-  # we care about
   DisabledByDefault: true
   TargetRubyVersion: 2.3
 Lint/Debugger:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.3
-before_install: gem install bundler -v 1.15.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If installed via `bundler`, be sure to use `bundle exec rubocop`. Otherwise, rub
 
 ## Enabled Cops
 
-Below are all the cops we have decided to enable unilaterally with any additional configurations that differ from the default. Each item is a link to the documentation at the _latest_ version of rubocop.
+Below are all the cops we have decided to enable unilaterally. Each item is a link to the documentation at the _latest_ version of rubocop.
 
 * [`AllCops`](http://rubocop.readthedocs.io/en/latest/cops/)
   * DisabledByDefault: true
@@ -45,22 +45,22 @@ Below are all the cops we have decided to enable unilaterally with any additiona
 * [`Metrics/LineLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength)
   * Max: 120
 * [`Style/Alias`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylealias)
-* [`Style/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleelsealignment)
-* [`Style/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinebetweendefs)
+* [`Style/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutelsealignment)
+* [`Style/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinebetweendefs)
   * AllowAdjacentOneLineDefs: true
-* [`Style/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylines)
-* [`Style/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundaccessmodifier)
-* [`Style/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundblockbody)
-* [`Style/EmptyLinesAroundClassBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundclassbody)
-* [`Style/EmptyLinesAroundMethodBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundmethodbody)
-* [`Style/EmptyLinesAroundModuleBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundmodulebody)
-* [`Style/EndOfLine`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleendofline)
-* [`Style/ExtraSpacing`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleextraspacing)
-* [`Style/IndentationWidth`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleindentationwidth)
+* [`Style/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylines)
+* [`Style/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundaccessmodifier)
+* [`Style/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundblockbody)
+* [`Style/EmptyLinesAroundClassBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundclassbody)
+* [`Style/EmptyLinesAroundMethodBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundmethodbody)
+* [`Style/EmptyLinesAroundModuleBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundmodulebody)
+* [`Style/EndOfLine`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutendofline)
+* [`Style/ExtraSpacing`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutextraspacing)
+* [`Style/IndentationWidth`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentationwidth)
 * [`Style/PreferredHashMethods`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylepreferredhashmethods)
-* [`Style/Tab`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletab)
-* [`Style/TrailingBlankLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletrailingblanklines)
-* [`Style/TrailingWhitespace`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletrailingwhitespace)
+* [`Style/Tab`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttab)
+* [`Style/TrailingBlankLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingblanklines)
+* [`Style/TrailingWhitespace`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingwhitespace)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -33,48 +33,30 @@ The gem also provides support for [Yelp pre-commit](http://pre-commit.com/). Sim
 
 If installed via `bundler`, be sure to use `bundle exec rubocop`. Otherwise, rubocop [won't be able to find the file](http://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-dependency-gem) when trying to load the config. Otherwise, you can run `rubocop` as usual with any options.
 
-## Style guide details
+## Enabled Cops
 
-* [`AllCops`](http://rubocop.readthedocs.io/en/latest/cops_style/#allcops)
+Below are all the cops we have decided to enable unilaterally. Each item is a link to the documentation at the _latest_ version of rubocop.
 
+* [`AllCops`](http://rubocop.readthedocs.io/en/latest/cops/)
 * [`Lint/Debugger`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintdebugger)
-
 * [`Lint/EndAlignment`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintendalignment)
-
 * [`Metrics/LineLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength)
-
 * [`Style/Alias`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylealias)
-
 * [`Style/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleelsealignment)
-
 * [`Style/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinebetweendefs)
-
 * [`Style/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylines)
-
 * [`Style/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundaccessmodifier)
-
 * [`Style/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundblockbody)
-
 * [`Style/EmptyLinesAroundClassBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundclassbody)
-
 * [`Style/EmptyLinesAroundMethodBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundmethodbody)
-
 * [`Style/EmptyLinesAroundModuleBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundmodulebody)
-
 * [`Style/EndOfLine`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleendofline)
-
 * [`Style/ExtraSpacing`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleextraspacing)
-
 * [`Style/IndentationWidth`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleindentationwidth)
-
 * [`Style/PreferredHashMethods`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylepreferredhashmethods)
-
 * [`Style/Tab`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletab)
-
 * [`Style/TrailingBlankLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletrailingblanklines)
-
 * [`Style/TrailingWhitespace`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletrailingwhitespace)
-
 
 ## Development
 
@@ -82,7 +64,7 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/outreach-ruby_style_guide. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/jpanderson-outreach/outreach-ruby_style_guide. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -90,4 +72,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the Outreach::RubyStyleGuide project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/outreach-ruby_style_guide/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Outreach::RubyStyleGuide project’s codebases and issue trackers is expected to follow the [code of conduct](https://github.com/jpanderson-outreach/outreach-ruby_style_guide/blob/master/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -35,15 +35,19 @@ If installed via `bundler`, be sure to use `bundle exec rubocop`. Otherwise, rub
 
 ## Enabled Cops
 
-Below are all the cops we have decided to enable unilaterally. Each item is a link to the documentation at the _latest_ version of rubocop.
+Below are all the cops we have decided to enable unilaterally with any additional configurations that differ from the default. Each item is a link to the documentation at the _latest_ version of rubocop.
 
 * [`AllCops`](http://rubocop.readthedocs.io/en/latest/cops/)
+  * DisabledByDefault: true
+  * TargetRubyVersion: 2.3
 * [`Lint/Debugger`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintdebugger)
 * [`Lint/EndAlignment`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintendalignment)
 * [`Metrics/LineLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength)
+  * Max: 120
 * [`Style/Alias`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylealias)
 * [`Style/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleelsealignment)
 * [`Style/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinebetweendefs)
+  * AllowAdjacentOneLineDefs: true
 * [`Style/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylines)
 * [`Style/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundaccessmodifier)
 * [`Style/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundblockbody)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,3 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
 
-RSpec::Core::RakeTask.new(:spec)
-
-task :default => :spec
+task :default => :test

--- a/bin/build_readme
+++ b/bin/build_readme
@@ -100,6 +100,8 @@ end
 def build_link(full_cop)
   type, cop = full_cop.split('/')
 
+  return 'http://rubocop.readthedocs.io/en/latest/cops/' if type == 'AllCops'
+
   "http://rubocop.readthedocs.io/en/latest/#{cop_type_link(type, cop)}/##{full_cop.downcase.gsub('/', '')}"
 end
 

--- a/bin/build_readme
+++ b/bin/build_readme
@@ -91,10 +91,18 @@ COP_TYPES = {
   'Bundler' => 'cops_bundler'
 }.freeze
 
+def layout_cop?(cop)
+  LAYOUT_COPS.include?(cop)
+end
+
 def cop_type_link(type, cop)
-  COP_TYPES.fetch(type) {
-    LAYOUT_COPS.include?(cop) ? 'cops_layout' : 'cops_style'
-  }
+  COP_TYPES.fetch(type) { layout_cop?(cop) ? 'cops_layout' : 'cops_style' }
+end
+
+def cop_anchor(type, cop)
+  return "#{type}#{cop}".downcase unless type == 'Style'
+
+  "#{layout_cop?(cop) ? 'layout' : 'style'}#{cop}".downcase
 end
 
 def build_link(full_cop)
@@ -102,7 +110,7 @@ def build_link(full_cop)
 
   return 'http://rubocop.readthedocs.io/en/latest/cops/' if type == 'AllCops'
 
-  "http://rubocop.readthedocs.io/en/latest/#{cop_type_link(type, cop)}/##{full_cop.downcase.gsub('/', '')}"
+  "http://rubocop.readthedocs.io/en/latest/#{cop_type_link(type, cop)}/##{cop_anchor(type, cop)}"
 end
 
 our_cops = YAML.load_file('.rubocop.yml')

--- a/bin/build_readme
+++ b/bin/build_readme
@@ -6,7 +6,7 @@ require 'yaml'
 # Sort the cops in case it hasn't already been done
 `./bin/sort_cops`
 
-# This is a nonsense list.
+# Unhappy aboaut this list being here.
 # Rubocop documents these cops as Layout cops, but they are in fact Style cops.
 # This is here so we can link to the documentation correctly.
 LAYOUT_COPS = [

--- a/bin/build_readme
+++ b/bin/build_readme
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+require 'erb'
+require 'yaml'
+
+# Sort the cops in case it hasn't already been done
+`./bin/sort_cops`
+
+# This is a nonsense list.
+# Rubocop documents these cops as Layout cops, but they are in fact Style cops.
+# This is here so we can link to the documentation correctly.
+LAYOUT_COPS = [
+  'AccessModifierIndentation',
+  'AlignArray',
+  'AlignHash',
+  'AlignParameters',
+  'BlockEndNewline',
+  'CaseIndentation',
+  'ClosingParenthesisIndentation',
+  'CommentIndentation',
+  'DotPosition',
+  'ElseAlignment',
+  'EmptyLineAfterMagicComment',
+  'EmptyLineBetweenDefs',
+  'EmptyLines',
+  'EmptyLinesAroundAccessModifier',
+  'EmptyLinesAroundBeginBody',
+  'EmptyLinesAroundBlockBody',
+  'EmptyLinesAroundClassBody',
+  'EmptyLinesAroundExceptionHandlingKeywords',
+  'EmptyLinesAroundMethodBody',
+  'EmptyLinesAroundModuleBody',
+  'EndOfLine',
+  'ExtraSpacing',
+  'FirstArrayElementLineBreak',
+  'FirstHashElementLineBreak',
+  'FirstMethodArgumentLineBreak',
+  'FirstMethodParameterLineBreak',
+  'FirstParameterIndentation',
+  'IndentArray',
+  'IndentAssignment',
+  'IndentHash',
+  'IndentHeredoc',
+  'IndentationConsistency',
+  'IndentationWidth',
+  'InitialIndentation',
+  'LeadingCommentSpace',
+  'MultilineArrayBraceLayout',
+  'MultilineAssignmentLayout',
+  'MultilineBlockLayout',
+  'MultilineHashBraceLayout',
+  'MultilineMethodCallBraceLayout',
+  'MultilineMethodCallIndentation',
+  'MultilineMethodDefinitionBraceLayout',
+  'MultilineOperationIndentation',
+  'RescueEnsureAlignment',
+  'SpaceAfterColon',
+  'SpaceAfterComma',
+  'SpaceAfterMethodName',
+  'SpaceAfterNot',
+  'SpaceAfterSemicolon',
+  'SpaceAroundBlockParameters',
+  'SpaceAroundEqualsInParameterDefault',
+  'SpaceAroundKeyword',
+  'SpaceAroundOperators',
+  'SpaceBeforeBlockBraces',
+  'SpaceBeforeComma',
+  'SpaceBeforeComment',
+  'SpaceBeforeFirstArg',
+  'SpaceBeforeSemicolon',
+  'SpaceInLambdaLiteral',
+  'SpaceInsideArrayPercentLiteral',
+  'SpaceInsideBlockBraces',
+  'SpaceInsideBrackets',
+  'SpaceInsideHashLiteralBraces',
+  'SpaceInsideParens',
+  'SpaceInsidePercentLiteralDelimiters',
+  'SpaceInsideRangeLiteral',
+  'SpaceInsideStringInterpolation',
+  'Tab',
+  'TrailingBlankLines',
+  'TrailingWhitespace'
+].freeze
+
+COP_TYPES = {
+  'Lint' => 'cops_lint',
+  'Performance' => 'cops_performance',
+  'Metrics' => 'cops_metrics',
+  'Rails' => 'cops_rails',
+  'Security' => 'cops_security',
+  'Bundler' => 'cops_bundler'
+}.freeze
+
+def cop_type_link(type, cop)
+  COP_TYPES.fetch(type) {
+    LAYOUT_COPS.include?(cop) ? 'cops_layout' : 'cops_style'
+  }
+end
+
+def build_link(full_cop)
+  type, cop = full_cop.split('/')
+
+  "http://rubocop.readthedocs.io/en/latest/#{cop_type_link(type, cop)}/##{full_cop.downcase.gsub('/', '')}"
+end
+
+our_cops = YAML.load_file('.rubocop.yml')
+
+RubcopCop = Struct.new(:full_cop_name, :configuration, :link)
+
+@full_built_cops = our_cops.map do |cop, config|
+  RubcopCop.new(cop, config, build_link(cop))
+end
+
+b = binding
+
+template = File.open('readme_template.md.erb') { |f| f.read }
+
+File.open('README.md', 'w') do |f|
+  f.write(ERB.new(template, 0, '<>-').result b)
+end

--- a/exe/outreach-rubocop
+++ b/exe/outreach-rubocop
@@ -1,1 +1,1 @@
-exec "rubocop #{ARGV.join(' ')}"
+exec 'rubocop',  ARGV.join(' ')

--- a/readme_template.md.erb
+++ b/readme_template.md.erb
@@ -33,11 +33,12 @@ The gem also provides support for [Yelp pre-commit](http://pre-commit.com/). Sim
 
 If installed via `bundler`, be sure to use `bundle exec rubocop`. Otherwise, rubocop [won't be able to find the file](http://rubocop.readthedocs.io/en/latest/configuration/#inheriting-configuration-from-a-dependency-gem) when trying to load the config. Otherwise, you can run `rubocop` as usual with any options.
 
-## Style guide details
+## Enabled Cops
+
+Below are all the cops we have decided to enable unilaterally. Each item is a link to the documentation at the _latest_ version of rubocop.
 
 <% @full_built_cops.each do |cop| -%>
 * [`<%= cop.full_cop_name %>`](<%= cop.link %>)
-
 <% end -%>
 
 ## Development
@@ -46,7 +47,7 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/outreach-ruby_style_guide. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/jpanderson-outreach/outreach-ruby_style_guide. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
@@ -54,4 +55,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the Outreach::RubyStyleGuide project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/outreach-ruby_style_guide/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the Outreach::RubyStyleGuide project’s codebases and issue trackers is expected to follow the [code of conduct](https://github.com/jpanderson-outreach/outreach-ruby_style_guide/blob/master/CODE_OF_CONDUCT.md).

--- a/readme_template.md.erb
+++ b/readme_template.md.erb
@@ -35,46 +35,10 @@ If installed via `bundler`, be sure to use `bundle exec rubocop`. Otherwise, rub
 
 ## Style guide details
 
-* [`AllCops`](http://rubocop.readthedocs.io/en/latest/cops_style/#allcops)
+<% @full_built_cops.each do |cop| -%>
+* [`<%= cop.full_cop_name %>`](<%= cop.link %>)
 
-* [`Lint/Debugger`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintdebugger)
-
-* [`Lint/EndAlignment`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintendalignment)
-
-* [`Metrics/LineLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength)
-
-* [`Style/Alias`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylealias)
-
-* [`Style/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleelsealignment)
-
-* [`Style/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinebetweendefs)
-
-* [`Style/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylines)
-
-* [`Style/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundaccessmodifier)
-
-* [`Style/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundblockbody)
-
-* [`Style/EmptyLinesAroundClassBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundclassbody)
-
-* [`Style/EmptyLinesAroundMethodBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundmethodbody)
-
-* [`Style/EmptyLinesAroundModuleBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleemptylinesaroundmodulebody)
-
-* [`Style/EndOfLine`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleendofline)
-
-* [`Style/ExtraSpacing`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleextraspacing)
-
-* [`Style/IndentationWidth`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styleindentationwidth)
-
-* [`Style/PreferredHashMethods`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylepreferredhashmethods)
-
-* [`Style/Tab`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletab)
-
-* [`Style/TrailingBlankLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletrailingblanklines)
-
-* [`Style/TrailingWhitespace`](http://rubocop.readthedocs.io/en/latest/cops_layout/#styletrailingwhitespace)
-
+<% end -%>
 
 ## Development
 

--- a/readme_template.md.erb
+++ b/readme_template.md.erb
@@ -39,6 +39,9 @@ Below are all the cops we have decided to enable unilaterally. Each item is a li
 
 <% @full_built_cops.each do |cop| -%>
 * [`<%= cop.full_cop_name %>`](<%= cop.link %>)
+<% cop.configuration.reject { |c| c == 'Enabled' }.each do |config| -%>
+  * <%= "#{config.first}: #{config.last}" %>
+<% end -%>
 <% end -%>
 
 ## Development


### PR DESCRIPTION
This pull request says it's creating a README, but there's more here than meets the eye.

1) There's a [pre-commit-hook.yaml](https://github.com/jpanderson-outreach/outreach-ruby_style_guide/blob/master/.pre-commit-hooks.yaml) that can be used. 
2) There is an executable, but it's primarily only useful for the pre-commit hook. `rubocop` alone should suffice otherwise (or `bundle exec rubocop` as stated in the README).
3) There is a script to generate the README with links to the rubocop docs based on a template.erb file which should be updated instead of the README itself.

All of the cops included in the `.rubocop.yml` file come from either the `outreach-cli` project or `outreach` application. I removed only a single cop when putting these in here, `Style/NumericPredicate`, simply because it's a bit more contentious of a rule. That said, we've already used it and decided it was worthwhile in the CLI so I could easily be convinced.

The project is built such that any project should be able to override any cop settings as they see fit. This simply seeks to provide a common rubric and common set. In an ideal world where all of our projects truly follow a single style guide, people _won't_ need to override anything except perhaps `Exclude` values because directories differ between projects. 