### PR TITLE
Upgrade rubocop and convert cops to Layout cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,35 @@
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.3
+Layout/ElseAlignment:
+  Enabled: true
+Layout/EmptyLineBetweenDefs:
+  Enabled: true
+  AllowAdjacentOneLineDefs: true
+Layout/EmptyLines:
+  Enabled: true
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+Layout/EndOfLine:
+  Enabled: true
+Layout/ExtraSpacing:
+  Enabled: true
+Layout/IndentationWidth:
+  Enabled: true
+Layout/Tab:
+  Enabled: true
+Layout/TrailingBlankLines:
+  Enabled: true
+Layout/TrailingWhitespace:
+  Enabled: true
 Lint/Debugger:
   Enabled: true
 Lint/EndAlignment:
@@ -13,34 +42,5 @@ Metrics/LineLength:
   Max: 120
 Style/Alias:
   Enabled: true
-Style/ElseAlignment:
-  Enabled: true
-Style/EmptyLineBetweenDefs:
-  Enabled: true
-  AllowAdjacentOneLineDefs: true
-Style/EmptyLines:
-  Enabled: true
-Style/EmptyLinesAroundAccessModifier:
-  Enabled: true
-Style/EmptyLinesAroundBlockBody:
-  Enabled: true
-Style/EmptyLinesAroundClassBody:
-  Enabled: true
-Style/EmptyLinesAroundMethodBody:
-  Enabled: true
-Style/EmptyLinesAroundModuleBody:
-  Enabled: true
-Style/EndOfLine:
-  Enabled: true
-Style/ExtraSpacing:
-  Enabled: true
-Style/IndentationWidth:
-  Enabled: true
 Style/PreferredHashMethods:
-  Enabled: true
-Style/Tab:
-  Enabled: true
-Style/TrailingBlankLines:
-  Enabled: true
-Style/TrailingWhitespace:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -40,28 +40,28 @@ Below are all the cops we have decided to enable unilaterally. Each item is a li
 * [`AllCops`](http://rubocop.readthedocs.io/en/latest/cops/)
   * DisabledByDefault: true
   * TargetRubyVersion: 2.3
+* [`Layout/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutelsealignment)
+* [`Layout/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinebetweendefs)
+  * AllowAdjacentOneLineDefs: true
+* [`Layout/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylines)
+* [`Layout/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundaccessmodifier)
+* [`Layout/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundblockbody)
+* [`Layout/EmptyLinesAroundClassBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundclassbody)
+* [`Layout/EmptyLinesAroundMethodBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundmethodbody)
+* [`Layout/EmptyLinesAroundModuleBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundmodulebody)
+* [`Layout/EndOfLine`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutendofline)
+* [`Layout/ExtraSpacing`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutextraspacing)
+* [`Layout/IndentationWidth`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentationwidth)
+* [`Layout/Tab`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttab)
+* [`Layout/TrailingBlankLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingblanklines)
+* [`Layout/TrailingWhitespace`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingwhitespace)
 * [`Lint/Debugger`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintdebugger)
 * [`Lint/EndAlignment`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintendalignment)
 * [`Lint/ShadowingOuterLocalVariable`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintshadowingouterlocalvariable)
 * [`Metrics/LineLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength)
   * Max: 120
 * [`Style/Alias`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylealias)
-* [`Style/ElseAlignment`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutelsealignment)
-* [`Style/EmptyLineBetweenDefs`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinebetweendefs)
-  * AllowAdjacentOneLineDefs: true
-* [`Style/EmptyLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylines)
-* [`Style/EmptyLinesAroundAccessModifier`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundaccessmodifier)
-* [`Style/EmptyLinesAroundBlockBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundblockbody)
-* [`Style/EmptyLinesAroundClassBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundclassbody)
-* [`Style/EmptyLinesAroundMethodBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundmethodbody)
-* [`Style/EmptyLinesAroundModuleBody`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutemptylinesaroundmodulebody)
-* [`Style/EndOfLine`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutendofline)
-* [`Style/ExtraSpacing`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutextraspacing)
-* [`Style/IndentationWidth`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentationwidth)
 * [`Style/PreferredHashMethods`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylepreferredhashmethods)
-* [`Style/Tab`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttab)
-* [`Style/TrailingBlankLines`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingblanklines)
-* [`Style/TrailingWhitespace`](http://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingwhitespace)
 
 ## Development
 

--- a/bin/build_readme
+++ b/bin/build_readme
@@ -6,103 +6,23 @@ require 'yaml'
 # Sort the cops in case it hasn't already been done
 `./bin/sort_cops`
 
-# Unhappy aboaut this list being here.
-# Rubocop documents these cops as Layout cops, but they are in fact Style cops.
-# This is here so we can link to the documentation correctly.
-LAYOUT_COPS = [
-  'AccessModifierIndentation',
-  'AlignArray',
-  'AlignHash',
-  'AlignParameters',
-  'BlockEndNewline',
-  'CaseIndentation',
-  'ClosingParenthesisIndentation',
-  'CommentIndentation',
-  'DotPosition',
-  'ElseAlignment',
-  'EmptyLineAfterMagicComment',
-  'EmptyLineBetweenDefs',
-  'EmptyLines',
-  'EmptyLinesAroundAccessModifier',
-  'EmptyLinesAroundBeginBody',
-  'EmptyLinesAroundBlockBody',
-  'EmptyLinesAroundClassBody',
-  'EmptyLinesAroundExceptionHandlingKeywords',
-  'EmptyLinesAroundMethodBody',
-  'EmptyLinesAroundModuleBody',
-  'EndOfLine',
-  'ExtraSpacing',
-  'FirstArrayElementLineBreak',
-  'FirstHashElementLineBreak',
-  'FirstMethodArgumentLineBreak',
-  'FirstMethodParameterLineBreak',
-  'FirstParameterIndentation',
-  'IndentArray',
-  'IndentAssignment',
-  'IndentHash',
-  'IndentHeredoc',
-  'IndentationConsistency',
-  'IndentationWidth',
-  'InitialIndentation',
-  'LeadingCommentSpace',
-  'MultilineArrayBraceLayout',
-  'MultilineAssignmentLayout',
-  'MultilineBlockLayout',
-  'MultilineHashBraceLayout',
-  'MultilineMethodCallBraceLayout',
-  'MultilineMethodCallIndentation',
-  'MultilineMethodDefinitionBraceLayout',
-  'MultilineOperationIndentation',
-  'RescueEnsureAlignment',
-  'SpaceAfterColon',
-  'SpaceAfterComma',
-  'SpaceAfterMethodName',
-  'SpaceAfterNot',
-  'SpaceAfterSemicolon',
-  'SpaceAroundBlockParameters',
-  'SpaceAroundEqualsInParameterDefault',
-  'SpaceAroundKeyword',
-  'SpaceAroundOperators',
-  'SpaceBeforeBlockBraces',
-  'SpaceBeforeComma',
-  'SpaceBeforeComment',
-  'SpaceBeforeFirstArg',
-  'SpaceBeforeSemicolon',
-  'SpaceInLambdaLiteral',
-  'SpaceInsideArrayPercentLiteral',
-  'SpaceInsideBlockBraces',
-  'SpaceInsideBrackets',
-  'SpaceInsideHashLiteralBraces',
-  'SpaceInsideParens',
-  'SpaceInsidePercentLiteralDelimiters',
-  'SpaceInsideRangeLiteral',
-  'SpaceInsideStringInterpolation',
-  'Tab',
-  'TrailingBlankLines',
-  'TrailingWhitespace'
-].freeze
-
 COP_TYPES = {
   'Lint' => 'cops_lint',
   'Performance' => 'cops_performance',
   'Metrics' => 'cops_metrics',
   'Rails' => 'cops_rails',
   'Security' => 'cops_security',
-  'Bundler' => 'cops_bundler'
+  'Bundler' => 'cops_bundler',
+  'Layout' => 'cops_layout',
+  'Style' => 'cops_style'
 }.freeze
 
-def layout_cop?(cop)
-  LAYOUT_COPS.include?(cop)
-end
-
 def cop_type_link(type, cop)
-  COP_TYPES.fetch(type) { layout_cop?(cop) ? 'cops_layout' : 'cops_style' }
+  COP_TYPES.fetch(type)
 end
 
 def cop_anchor(type, cop)
-  return "#{type}#{cop}".downcase unless type == 'Style'
-
-  "#{layout_cop?(cop) ? 'layout' : 'style'}#{cop}".downcase
+  "#{type}#{cop}".downcase
 end
 
 def build_link(full_cop)

--- a/outreach-ruby_style_guide.gemspec
+++ b/outreach-ruby_style_guide.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.48.1'
+  spec.add_dependency 'rubocop', '~> 0.49.1'
 
   spec.add_development_dependency 'pry', '~> 0.10 '
   spec.add_development_dependency 'bundler', '~> 1.15'


### PR DESCRIPTION
This is to upgrade the version of rubocop required to 0.49. I wanted to make the version looser, but they often introduce new cops with minor versions which could break people's builds unexpectedly. Has to be deliberate.

Mostly, this upgrade gets us the `Layout` department.