### PR TITLE
Add Metrics cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,9 +37,15 @@ Lint/EndAlignment:
   Enabled: true
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
+Metrics/BlockLength:
+  Enabled: true
+Metrics/BlockNesting:
+  Enabled: true
 Metrics/LineLength:
   Enabled: true
   Max: 120
+Metrics/ParameterLists:
+  Enabled: true
 Style/Alias:
   Enabled: true
 Style/PreferredHashMethods:

--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ Below are all the cops we have decided to enable unilaterally. Each item is a li
 * [`Lint/Debugger`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintdebugger)
 * [`Lint/EndAlignment`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintendalignment)
 * [`Lint/ShadowingOuterLocalVariable`](http://rubocop.readthedocs.io/en/latest/cops_lint/#lintshadowingouterlocalvariable)
+* [`Metrics/BlockLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricsblocklength)
+* [`Metrics/BlockNesting`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricsblocknesting)
 * [`Metrics/LineLength`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricslinelength)
   * Max: 120
+* [`Metrics/ParameterLists`](http://rubocop.readthedocs.io/en/latest/cops_metrics/#metricsparameterlists)
 * [`Style/Alias`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylealias)
 * [`Style/PreferredHashMethods`](http://rubocop.readthedocs.io/en/latest/cops_style/#stylepreferredhashmethods)
 


### PR DESCRIPTION
Add Metrics department cops to the list of things we care about.

Hm. Should probably add the Readme some details about BlockLength and BlockNesting for excluding them for spec and test files. Or they should be added here; running from the base of the ruby application's directory it should evaluate the files just fine.